### PR TITLE
Add requirements section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ This kernel adds support for Elm to [Jupyter](http://jupyter.org/) notebooks.
 While basic functionality is in place, this is still very much a work in
 progress. I'm still figuring it all out. Any help, ideas, etc. would be great.
 
+# Requirements
+- Python 3.6+
+
 # Installation
 
 Either install from a repository using `pip`:


### PR DESCRIPTION
I couldn't run Elm code due to following error:
```__init__() got an unexpected keyword argument 'encoding'```

According to python documentation,`subprocess.run`'s `encoding` argument was introduced in [python 3.6](https://docs.python.org/3.6/library/subprocess.html#subprocess.run) 

> Changed in version 3.6: Added encoding and errors parameters
