### PR TITLE
Addressing issue #25

### DIFF
--- a/elm_kernel/kernel.py
+++ b/elm_kernel/kernel.py
@@ -54,7 +54,7 @@ class ElmKernel(Kernel):
         }
 
     @contextlib.contextmanager
-    def _tempfile(self, filename):
+    def _temp_path(self, filename):
         """Yield `filename` inside the tempdir, but don't actually create the file.
         Then, on exit, delete the file if it exists.
         """
@@ -64,6 +64,7 @@ class ElmKernel(Kernel):
         finally:
             with contextlib.suppress(OSError):
                 os.remove(path)
+                shutil.rmtree(path, ignore_errors=True)
     
     def _elm_init(self):
         ''' Generate an init file in the temporary directory
@@ -94,9 +95,10 @@ class ElmKernel(Kernel):
     def _compile(self, code):
         self._copy_elm_json_file_to_tempdir()
 
-        with self._tempfile('input.elm') as infile,\
-             self._tempfile('index.js')  as outfile,\
-             self._tempfile('elm.json')  as elm_json:
+        with self._temp_path('input.elm') as infile,\
+             self._temp_path('index.js')  as outfile,\
+             self._temp_path('elm.json')  as elm_json,\
+             self._temp_path('src') as src_path:
 
             with open(infile, mode='wt') as f:
                 f.write(code)
@@ -105,14 +107,17 @@ class ElmKernel(Kernel):
                 # if elm.json doesn't exist yet, create it
                 if not os.path.isfile(elm_json):
                     self._elm_init()
+                if not os.path.isdir(src_path):
+                    os.mkdir(src_path)
                 
                 self._elm_make(infile, outfile)
+
 
                 with open(outfile, mode='rt') as f:
                     javascript = f.read()
 
                 self._send_success_result(javascript)
-
+            
             except subprocess.CalledProcessError as err:
                 # When compilation fails we send the compiler output to the
                 # user but we don't count this as an error. A compiler error
@@ -207,6 +212,7 @@ class ElmKernel(Kernel):
         # existence of elm.json is not mandatory
         if os.path.isfile('elm.json'):
             shutil.copy('elm.json', self._tempdir.name)
+
 
 if __name__ == '__main__':
     from ipykernel.kernelapp import IPKernelApp

--- a/elm_kernel/kernel.py
+++ b/elm_kernel/kernel.py
@@ -112,12 +112,11 @@ class ElmKernel(Kernel):
                 
                 self._elm_make(infile, outfile)
 
-
                 with open(outfile, mode='rt') as f:
                     javascript = f.read()
 
                 self._send_success_result(javascript)
-            
+
             except subprocess.CalledProcessError as err:
                 # When compilation fails we send the compiler output to the
                 # user but we don't count this as an error. A compiler error
@@ -212,7 +211,6 @@ class ElmKernel(Kernel):
         # existence of elm.json is not mandatory
         if os.path.isfile('elm.json'):
             shutil.copy('elm.json', self._tempdir.name)
-
 
 if __name__ == '__main__':
     from ipykernel.kernelapp import IPKernelApp


### PR DESCRIPTION
In elm 0.19.1 compilation fails without the source directories listed in `elm.json`. `_elm_init` ensures a source directory exists, however when the user provides an `elm.json` we did not ensure its existence.

Summary of changes:
- updated _tempfile to also produce temporary directories, renamed it to _temp_path.
- changed _compile to generate temporary source directory when using elm.json.